### PR TITLE
Add ability to store expanded state in LocalStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,22 @@ Clear Background (default theme):
 
 Yaml:
 
-| Name                      | Type     | Default       | Supported options      | Description                                           |
-| ------------------------- | -------- | ------------- | ---------------------- | ----------------------------------------------------- |
-| type                      | string   | **Required**  | `custom:expander-card` | Type of the card.                                     |
-| title                     | string   | _Expander_    | *                      | Title (Not displayed if using Title-Card)             |
-| clear                     | boolean  | _false_       | true\|false            | Remove Background                                     |
-| expanded                  | boolean  | _false_       | true\|false            | Start expanded                                        |
-| button-background         | string   | _transparent_ | css-color              | Background color of expand button                     |
-| gap                       | string   | _0.6em_       | css-size               | gap between child cards                               |
-| padding                   | string   | _1em_         | css-size               | padding of all card content                           |
-| child-padding             | string   | _0.5em_       | css-size               | padding of child cards                                |
-| title-card                | object   | **optional**  | LovelaceCardConfig     | Replace Title with card                               |
-| title-card-padding        | string   | _0px_         | css-size               | padding of title-card                                 |
-| title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card                 |
-| overlay-margin            | string   | _2em_         | css-size               | Margin from top right of expander button (if overlay) |
-| cards                     | object[] | **optional**  | LovelaceCardConfig[]   | Child cards to show when expanded                     |
+| Name                      | Type     | Default       | Supported options      | Description                                                    |
+| ------------------------- | -------- | ------------- | ---------------------- | -------------------------------------------------------------- |
+| type                      | string   | **Required**  | `custom:expander-card` | Type of the card.                                              |
+| title                     | string   | _Expander_    | *                      | Title (Not displayed if using Title-Card)                      |
+| clear                     | boolean  | _false_       | true\|false            | Remove Background                                              |
+| expanded                  | boolean  | _false_       | true\|false            | Start expanded                                                 |
+| expand-id                 | string   | **optional**  | string                 | Unique ID to use for JS LocalStorage. Will save expanded state |
+| button-background         | string   | _transparent_ | css-color              | Background color of expand button                              |
+| gap                       | string   | _0.6em_       | css-size               | gap between child cards                                        |
+| padding                   | string   | _1em_         | css-size               | padding of all card content                                    |
+| child-padding             | string   | _0.5em_       | css-size               | padding of child cards                                         |
+| title-card                | object   | **optional**  | LovelaceCardConfig     | Replace Title with card                                        |
+| title-card-padding        | string   | _0px_         | css-size               | padding of title-card                                          |
+| title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card                          |
+| overlay-margin            | string   | _2em_         | css-size               | Margin from top right of expander button (if overlay)          |
+| cards                     | object[] | **optional**  | LovelaceCardConfig[]   | Child cards to show when expanded                              |
 
 ## Installation
 

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -49,8 +49,13 @@
         if (isEditorMode) {
             expanded = true;
         } else {
-            if (config.expanded !== undefined) {
-                setTimeout(() => (expanded = config.expanded as boolean), 100);
+            let configExpanded = config.expanded;
+            if (config['expand-id'] !== undefined) {
+              const storageValue = localStorage.getItem(`expander-${config['expand-id']}`);
+              configExpanded = storageValue ? storageValue === 'true' : configExpanded;
+            }
+            if (configExpanded !== undefined) {
+                setTimeout(() => (expanded = configExpanded as boolean), 100);
             }
         }
     });
@@ -85,6 +90,9 @@
                 class={`header ripple ${config['title-card-button-overlay'] ? 'header-overlay' : ''}`}
                 on:click={() => {
                     expanded = !expanded;
+                    if (config['expand-id'] !== undefined) {
+                      localStorage.setItem(`expander-${config['expand-id']}`,expanded ? 'true' : 'false');
+                    }
                 }}
             >
                 <ha-icon icon="mdi:chevron-down" class={`primaryico ${expanded ? 'flipped' : ''}`} />
@@ -95,6 +103,9 @@
             class="header ripple"
             on:click={() => {
                 expanded = !expanded;
+                if (config['expand-id'] !== undefined) {
+                  localStorage.setItem(`expander-${config['expand-id']}`,expanded ? 'true' : 'false');
+                }
             }}
             style="--button-background:{config['button-background']};"
         >

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -51,8 +51,10 @@
         } else {
             let configExpanded = config.expanded;
             if (config['expand-id'] !== undefined) {
-              const storageValue = localStorage.getItem(`expander-${config['expand-id']}`);
-              configExpanded = storageValue ? storageValue === 'true' : configExpanded;
+              try {
+                const storageValue = localStorage.getItem(`expander-${config['expand-id']}`);
+                configExpanded = storageValue ? storageValue === 'true' : configExpanded;
+              } catch { }
             }
             if (configExpanded !== undefined) {
                 setTimeout(() => (expanded = configExpanded as boolean), 100);
@@ -91,7 +93,10 @@
                 on:click={() => {
                     expanded = !expanded;
                     if (config['expand-id'] !== undefined) {
-                      localStorage.setItem(`expander-${config['expand-id']}`,expanded ? 'true' : 'false');
+                      try {
+                        localStorage.setItem(`expander-${config['expand-id']}`,expanded ? 'true' : 'false');
+                      }
+                      catch { }
                     }
                 }}
             >
@@ -104,7 +109,10 @@
             on:click={() => {
                 expanded = !expanded;
                 if (config['expand-id'] !== undefined) {
-                  localStorage.setItem(`expander-${config['expand-id']}`,expanded ? 'true' : 'false');
+                  try {
+                    localStorage.setItem(`expander-${config['expand-id']}`,expanded ? 'true' : 'false');
+                  }
+                  catch { }
                 }
             }}
             style="--button-background:{config['button-background']};"

--- a/src/ExpanderCardEditor.svelte
+++ b/src/ExpanderCardEditor.svelte
@@ -45,8 +45,11 @@ limitations under the License.
         'expanded': ['boolean', {
             label: 'Start expanded (Always expanded in editor)'
         }],
+        'expand-id': ['string', {
+            label: 'LocalStorage ID'
+        }],
         'button-background': ['string', {
-            label: 'Button background (CSS color'
+            label: 'Button background (CSS color)'
         }],
         'gap': ['string', {
             label: 'Gap between cards'

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -24,5 +24,6 @@ export interface ExpanderConfig {
     'overlay-margin'?: string;
     'child-padding'?: string;
     expanded?: boolean;
+    'expand-id'?: string;
     'button-background': string;
 }


### PR DESCRIPTION
I added a new setting that lets this card remember its previously toggled expand state. When this setting is set, the card will load its expanded state from storage upon page reload.

A new config setting 'expand-id' is introduced to create a unique identifier for this card in LocalStorage. If set, the item 'expander-<expand-id>' will be set each time the card is opened or closed.

When loading state from LocalStorage, the fallback scenario is to use the config value set for 'expanded'.